### PR TITLE
feat: import api-models from proto repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,10 @@ features = ["bundled"]
 anyhow = "1.0.95"
 async-trait = "0.1.85"
 tokio = {version = "1.42.0", features = ["full"]}
+tonic = "0.12.3"
+prost = "0.13.4"
+tonic-reflection = "0.12.3"
+tower-http = "0.6.2"
+tonic-web = "0.12.3"
+prost-types = "0.13.4"
+moss-street-api-models = { git = "https://github.com/moss-street/api-models/", version = "0.1.0" }


### PR DESCRIPTION
this will build on top of the latest fix to the api models repo to generate a local `lib.rs` and export that as a lib crate.