### PR TITLE
feat: connect server to db_manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ prost-types = "0.13.4"
 moss-street-api-models = { git = "https://github.com/moss-street/api-models/", version = "0.1.0" }
 r2d2_sqlite = "0.25.0"
 r2d2 = "0.8.10"
+derive_builder = "0.20.2"
+bcrypt = "0.16.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,10 @@
+use std::sync::Arc;
+
 use anyhow::Result;
-use moss_street_libs::http::{dependencies::ServerDependencies, server::Server};
+use moss_street_libs::{
+    db::manager::DBManager,
+    http::{dependencies::ServerDependencies, server::Server},
+};
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
@@ -8,8 +13,9 @@ use r2d2_sqlite::SqliteConnectionManager;
 async fn main() -> Result<()> {
     let manager = SqliteConnectionManager::file("local.db");
     let pool = Pool::new(manager)?;
+    let db_manager = Arc::new(DBManager::new(pool));
 
-    let dependencies = ServerDependencies::new(pool);
+    let dependencies = ServerDependencies::new(db_manager);
 
     let ip = "127.0.0.1:6969";
     let addr = ip.parse()?;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,2 @@
+pub mod manager;
+pub mod schemas;

--- a/src/db/schemas/mod.rs
+++ b/src/db/schemas/mod.rs
@@ -1,0 +1,2 @@
+pub mod stock;
+pub mod user;

--- a/src/db/schemas/stock.rs
+++ b/src/db/schemas/stock.rs
@@ -1,0 +1,31 @@
+use crate::db::manager::TableImpl;
+use rusqlite::Row;
+
+#[allow(unused)]
+pub struct Stock {
+    id: i32,
+    name: String,
+}
+
+impl TableImpl for Stock {
+    fn create_table_query() -> String {
+        String::from(
+            r#"CREATE TABLE IF NOT EXISTS Stock (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);"#,
+        )
+    }
+
+    fn generate_db_load_query(&self) -> String {
+        todo!()
+    }
+
+    fn generate_db_lookup_query(_id: i32) -> String {
+        todo!()
+    }
+
+    fn deserialize_query_result(_result: &Row) -> Result<Self, rusqlite::Error> {
+        todo!()
+    }
+}

--- a/src/db/schemas/user.rs
+++ b/src/db/schemas/user.rs
@@ -1,0 +1,51 @@
+use derive_builder::Builder;
+use rusqlite::Row;
+use tokio::time::Instant;
+
+use crate::{db::manager::TableImpl, passwords::Password};
+
+#[derive(Debug, Builder)]
+pub struct User {
+    // id is optinal because when we create a new item in the db, we don't actually set the id, we
+    // let sqlite do that. We only set this field when we read from the db.
+    _id: Option<i32>,
+    email: String,
+    password: Password,
+    first_name: String,
+    last_name: String,
+    created_at: Instant,
+}
+
+impl TableImpl for User {
+    fn create_table_query() -> String {
+        String::from(
+            r#"CREATE TABLE IF NOT EXISTS User (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL,
+    first_name TEXT NOT NULL,
+    last_name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);"#,
+        )
+    }
+
+    fn generate_db_load_query(&self) -> String {
+        format!(
+            "INSERT INTO User (email, password, first_name, last_name, created_at) VALUES ('{}', '{}', '{}', '{}', '{:#?}')",
+            self.email.replace('\'', "''"), // Escape single quotes
+            self.password.hashed(),
+            self.first_name,
+            self.last_name,
+            self.created_at
+        )
+    }
+
+    fn generate_db_lookup_query(_id: i32) -> String {
+        todo!()
+    }
+
+    fn deserialize_query_result(_result: &Row) -> Result<Self, rusqlite::Error> {
+        todo!()
+    }
+}

--- a/src/http/dependencies.rs
+++ b/src/http/dependencies.rs
@@ -1,15 +1,14 @@
-use r2d2::{Pool, PooledConnection};
-use r2d2_sqlite::SqliteConnectionManager;
+use std::sync::Arc;
 
+use crate::db::manager::DBManager;
+
+#[derive(Debug)]
 pub struct ServerDependencies {
-    db_pool: Pool<SqliteConnectionManager>,
+    pub db_manager: Arc<DBManager>,
 }
 
 impl ServerDependencies {
-    pub fn new(db_pool: Pool<SqliteConnectionManager>) -> Self {
-        Self { db_pool }
-    }
-    pub fn get_connection(&self) -> Option<PooledConnection<SqliteConnectionManager>> {
-        self.db_pool.try_get()
+    pub fn new(db_manager: Arc<DBManager>) -> Self {
+        Self { db_manager }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod db;
 pub mod http;
+pub(crate) mod passwords;
 pub(crate) mod services;

--- a/src/passwords.rs
+++ b/src/passwords.rs
@@ -1,0 +1,58 @@
+use bcrypt::{hash, verify, DEFAULT_COST};
+
+#[derive(Debug, Clone)]
+pub struct Password {
+    hashed_password: String,
+}
+
+impl Password {
+    /// Creates a new `Password` instance by hashing the provided plaintext password.
+    ///
+    /// # Arguments
+    /// * `plaintext` - The plaintext password to hash.
+    ///
+    /// # Returns
+    /// A `Result` containing the `Password` instance or an error if hashing fails.
+    pub fn new(plaintext: &str) -> Result<Self, bcrypt::BcryptError> {
+        let hashed = hash(plaintext, DEFAULT_COST)?;
+        Ok(Self {
+            hashed_password: hashed,
+        })
+    }
+
+    /// Verifies a plaintext password against the hashed password.
+    ///
+    /// # Arguments
+    /// * `plaintext` - The plaintext password to verify.
+    ///
+    /// # Returns
+    /// A `Result` containing `true` if the password matches, `false` otherwise,
+    /// or an error if verification fails.
+    pub fn verify(&self, plaintext: &str) -> Result<bool, bcrypt::BcryptError> {
+        verify(plaintext, &self.hashed_password)
+    }
+
+    /// Gets the hashed password as a reference string.
+    pub fn hashed(&self) -> &str {
+        &self.hashed_password
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Password;
+
+    #[test]
+    fn test_password_hashing_and_verification() {
+        let plaintext = "my_secure_password";
+
+        // Create a new Password instance
+        let password = Password::new(plaintext).unwrap();
+
+        // Verify that the hashed password matches the plaintext
+        assert!(password.verify(plaintext).unwrap());
+
+        // Verify that an incorrect password does not match
+        assert!(!password.verify("wrong_password").unwrap());
+    }
+}


### PR DESCRIPTION
Modified the dependencies struct to just take db_manager since the server doesn't need access to the pool. The db_manager will now take ownership of the sqlite pool and execute queries on behalf of the server.

issue: https://github.com/moss-street/server-backend/issues/12