### PR TITLE
chore: remove windows runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,6 @@ jobs:
           os: macos-latest
         - target: aarch64-apple-darwin
           os: macos-latest
-        - target: x86_64-pc-windows-msvc
-          os: windows-lastest
             
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The windows runner keeps failing to get picked up. The only one working on the project using a windows machine is able to build locally anyway so we don't need to compile a release build for it.