### PR TITLE
chore: add unit testing to session/manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = ["bundled"]
 [dependencies]
 anyhow = "1.0.95"
 async-trait = "0.1.85"
-tokio = {version = "1.42.0", features = ["full"]}
+tokio = { version = "1.42.0", features = ["full", "test-util"] }
 tonic = "0.12.3"
 prost = "0.13.4"
 tonic-reflection = "0.12.3"
@@ -33,5 +33,5 @@ r2d2 = "0.8.10"
 derive_builder = "0.20.2"
 bcrypt = "0.16.0"
 chrono = "0.4.39"
-diesel = {version = "2.2", features = ["r2d2", "sqlite", "chrono"]}
+diesel = { version = "2.2", features = ["r2d2", "sqlite", "chrono"] }
 clap = { version = "4.5.27", features = ["derive"] }

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -19,7 +19,7 @@ pub(crate) mod schema {
     }
 }
 
-#[derive(Debug, Builder, Clone, Queryable, Selectable, Insertable)]
+#[derive(Debug, Builder, Clone, Queryable, Selectable, Insertable, PartialEq, Eq)]
 #[diesel(table_name = schema::users)]
 pub struct User {
     // id is optinal because when we create a new item in the db, we don't actually set the id, we

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -1,4 +1,4 @@
-use bcrypt::{hash, DEFAULT_COST};
+use bcrypt::hash;
 use chrono::{DateTime, Duration, Utc};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -6,6 +6,8 @@ use std::sync::{Arc, RwLock};
 use prost_types::Timestamp;
 
 use crate::db::models::user::User;
+
+const DEFAULT_TOKEN_TIMEOUT_DURATION: Duration = Duration::seconds(30);
 
 #[derive(Debug, Clone)]
 #[allow(unused)]
@@ -17,8 +19,20 @@ pub struct Session {
 }
 
 impl Session {
+    fn new(user: User, user_id: i32, expire_duration: Duration) -> Self {
+        let token = SessionToken::new(user_id);
+        let create_time = get_time();
+        let expire_time = create_time + expire_duration;
+        Self {
+            token,
+            user: user.clone(),
+            expire_time,
+            create_time,
+        }
+    }
+
     fn is_valid(&self) -> bool {
-        let now = Utc::now();
+        let now = get_time();
         now < self.expire_time
     }
 }
@@ -47,14 +61,18 @@ pub struct SessionToken(String);
 impl SessionToken {
     fn new(user_id: i32) -> Self {
         // Get the current timestamp
-        let now: DateTime<Utc> = Utc::now();
+        let now = get_time();
         let timestamp = now.to_rfc3339();
 
         // Concatenate the user ID and timestamp
         let input = format!("{}:{}", user_id, timestamp);
 
         // Hash the input using bcrypt
-        match hash(input, DEFAULT_COST) {
+        // 4 is the lowest cost of the hash function making this faster
+        // Since we're generating a sesion token it's ok for this to be
+        // not as fast as a password hash. Changing this value to default cost
+        // can take up to 600ms instead of 5ms.
+        match hash(input, 4) {
             Ok(hashed) => Self(hashed),
             Err(e) => {
                 eprintln!("Failed to generate bcrypt hash: {}", e);
@@ -93,28 +111,134 @@ impl SessionManagerImpl for SessionManager {
     }
 
     fn new_session(&self, user: User) -> Option<Session> {
-        let token = SessionToken::new(user.id?);
-        let create_time = Utc::now();
-        let expire_time: DateTime<Utc> = create_time + Duration::seconds(30);
-        let session = Session {
-            token: token.clone(),
-            user,
-            expire_time,
-            create_time,
-        };
+        let session = Session::new(user.clone(), user.id?, DEFAULT_TOKEN_TIMEOUT_DURATION);
 
         let mut sessions = self.sessions.write().unwrap();
-        sessions.insert(token.clone(), session.clone());
+        sessions.insert(session.token.clone(), session.clone());
         Some(session)
     }
 
     fn cleanup(&self) {
-        // Periodically call this I guess.
-        let now = Utc::now();
-
         self.sessions
             .write()
             .unwrap()
-            .retain(|_, session| session.expire_time > now);
+            .retain(|_, session| session.is_valid());
+    }
+}
+
+/// Returns a time based on Utc now, this provides a special way to return the time when testing is
+/// enabled to accelerate time for Utc. Since Utc is not compatible with tokio::Instant this is
+/// necessary to mock the chrono timestamps. If testing is enabled then this will always return the
+/// same time
+fn get_time() -> DateTime<Utc> {
+    #[cfg(not(test))]
+    {
+        Utc::now()
+    }
+    #[cfg(test)]
+    {
+        use chrono::TimeZone;
+        Utc.timestamp_opt(test_utils::get_mock_time(), 0).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use std::sync::atomic::{AtomicI64, Ordering};
+    // Atomic clock mock
+    static MOCK_TIME: AtomicI64 = AtomicI64::new(0);
+
+    pub fn set_mock_time(seconds: i64) {
+        MOCK_TIME.store(seconds, Ordering::SeqCst);
+    }
+
+    pub fn get_mock_time() -> i64 {
+        MOCK_TIME.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn fake_user() -> User {
+        User {
+            id: Some(123),
+            email: "abd".to_owned(),
+            password: "123".to_owned(),
+            first_name: "bob".to_owned(),
+            last_name: "bob".to_owned(),
+        }
+    }
+
+    #[test]
+    fn test_session_is_valid() {
+        let user = fake_user();
+
+        let expire_duration = Duration::seconds(1);
+        let session = Session::new(user, 123, expire_duration);
+
+        assert!(session.is_valid());
+
+        test_utils::set_mock_time(test_utils::get_mock_time() + 1); // Fast-forward time
+        assert!(!session.is_valid());
+    }
+
+    #[test]
+    fn test_new_session() {
+        let manager = SessionManager::default();
+        let user = fake_user();
+
+        let session = manager
+            .new_session(user.clone())
+            .expect("Session should be created");
+        assert_eq!(session.user, user);
+        assert!(session.is_valid());
+    }
+
+    #[test]
+    fn test_get_session() {
+        let manager = SessionManager::default();
+        let user = fake_user();
+        let session = manager
+            .new_session(user.clone())
+            .expect("Session should be created");
+
+        let retrieved = manager
+            .get_session(session.token.clone())
+            .expect("Session should exist");
+        assert_eq!(retrieved.user, user);
+    }
+
+    #[test]
+    fn test_validate_session() {
+        let manager = SessionManager::default();
+        let user = fake_user();
+        let session = manager
+            .new_session(user.clone())
+            .expect("Session should be created");
+
+        let validated_user = manager
+            .validate_session(session.clone())
+            .expect("Session should be valid");
+        assert_eq!(validated_user, user);
+    }
+
+    #[test]
+    fn test_expired_session_cleanup() {
+        let manager = SessionManager::default();
+        let user = fake_user();
+        test_utils::set_mock_time(Utc::now().timestamp());
+        let session = manager
+            .new_session(user.clone())
+            .expect("Session should be created");
+
+        test_utils::set_mock_time(test_utils::get_mock_time() + 35); // Fast-forward time
+        manager.cleanup();
+
+        assert!(
+            manager.get_session(session.token).is_none(),
+            "Expired session should be removed"
+        );
     }
 }


### PR DESCRIPTION
this change adds some unit tests to session manager and also refactors a little bit in how we get the chorono datetime object so it can be mocked.

also caught a bug with the cleanup function not actually cleaning up so fixed that too