### PR TITLE
fix: use latest tag on release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Get latest release tag
       id: get_version
       run: |
-        latest_tag=$(git tag --sort=-v:refname | head -n 1)
+        latest_tag=$(git tag --sort=-v:refname | tail -n 1)
         if [[ -z "$latest_tag" || ! "$latest_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           latest_tag="0.0.0"
         fi


### PR DESCRIPTION
latest tag is at the tail of the list instead of the head apparently