### PR TITLE
fix: script for tagging new releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,16 +55,21 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with: 
+        fetch-depth: 0
       
     - name: Get latest release tag
       id: get_version
       run: |
-        latest_tag=$(git tag --sort=-v:refname | tail -n 1)
+        latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+        echo "Latest tag: $latest_tag"
+
         if [[ -z "$latest_tag" || ! "$latest_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           latest_tag="0.0.0"
         fi
         IFS='.' read -r major minor patch <<< "$latest_tag"
         new_tag="$major.$minor.$((patch+1))"
+        echo "New version: $new_tag"
         echo "new_version=$new_tag" >> $GITHUB_ENV
       
     - name: Download artifacts


### PR DESCRIPTION
Fixed the script to properly build and tag a new release when merged to main.

https://github.com/moss-street/server-backend/issues/27